### PR TITLE
#167727340 Users should get stats of trips made in the last X timeframe

### DIFF
--- a/src/controllers/tripController.js
+++ b/src/controllers/tripController.js
@@ -1,6 +1,6 @@
 import {
   postTrip, updateTripStatus, getRequesterEmail, bulkCreate,
-  getTripRequests, findOneTripRequest, rejectRequest
+  getTripRequests, findOneTripRequest, rejectRequest, fetchUserTripStats, fetchTripStats
 } from '../services/tripServices';
 import { respondWithSuccess, respondWithWarning } from '../helpers/responseHandler';
 import statusCode from '../helpers/statusCode';
@@ -165,6 +165,30 @@ export const rejectTripRequest = async (req, res) => {
   try {
     const [, tripRequest] = await rejectRequest(req.params.tripId, status);
     return respondWithSuccess(res, statusCode.success, 'Trip request was rejected', tripRequest.toJSON());
+  } catch (error) {
+    return respondWithWarning(res, statusCode.internalServerError, error.message);
+  }
+};
+
+export const getUserTripStats = async (req, res, next) => {
+  try {
+    const { date } = req.body;
+    const { id, roleId } = req.auth;
+    if (roleId === 6) {
+      const stats = await fetchUserTripStats(date, id);
+      return respondWithSuccess(res, statusCode.success, 'Resource successfully fetched', stats);
+    }
+    return next();
+  } catch (error) {
+    return respondWithWarning(res, statusCode.internalServerError, error.message);
+  }
+};
+
+export const getTripStats = async (req, res) => {
+  try {
+    const { date } = req.body;
+    const stats = await fetchTripStats(date);
+    return respondWithSuccess(res, statusCode.success, 'Resource successfully fetched', stats);
   } catch (error) {
     return respondWithWarning(res, statusCode.internalServerError, error.message);
   }

--- a/src/database/migrations/20190910230142-create-flight.js
+++ b/src/database/migrations/20190910230142-create-flight.js
@@ -44,5 +44,5 @@ export default {
       defaultValue: new Date()
     }
   }),
-  down: (queryInterface, Sequelize) => queryInterface.dropTable('Flights')
+  down: (queryInterface) => queryInterface.dropTable('Flights')
 };

--- a/src/database/seeders/20190824102850-create-permissions-seeder.js
+++ b/src/database/seeders/20190824102850-create-permissions-seeder.js
@@ -130,6 +130,9 @@ export default {
     {
       actionName: 'VIEW_CHAT_MESSAGE',
     },
+    {
+      actionName: 'VIEW_TRIP_STATS',
+    }
   ], {}),
 
   down: (queryInterface, Sequelize) => queryInterface.bulkDelete('Permissions', null, {})

--- a/src/database/seeders/20190826080729-create-role-permissions-seeders.js
+++ b/src/database/seeders/20190826080729-create-role-permissions-seeders.js
@@ -484,7 +484,27 @@ export default {
     {
       roleId: 6,
       permissionId: 43
-    }
+    },
+    {
+      roleId: 1,
+      permissionId: 44
+    },
+    {
+      roleId: 2,
+      permissionId: 44
+    },
+    {
+      roleId: 3,
+      permissionId: 44
+    },
+    {
+      roleId: 4,
+      permissionId: 44
+    },
+    {
+      roleId: 6,
+      permissionId: 44
+    },
   ], {}),
 
   down: (queryInterface, Sequelize) => queryInterface.bulkDelete('RolePermissions', null, {})

--- a/src/docs/swagger/definitions/trip.js
+++ b/src/docs/swagger/definitions/trip.js
@@ -198,3 +198,13 @@ export const rejectTripRequest = {
     }
   }
 };
+
+export const getTripStats = {
+  type: 'object',
+  properties: {
+    date: {
+      type: 'string',
+      example: '2019-09-10'
+    }
+  }
+};

--- a/src/docs/swagger/paths/trips.js
+++ b/src/docs/swagger/paths/trips.js
@@ -364,3 +364,61 @@ export const rejectTripPath = {
     }
   }
 };
+
+export const getTripStatsPath = {
+  post: {
+    tags: [
+      'trips'
+    ],
+    security: [
+      {
+        BearerToken: []
+      }
+    ],
+    summary: 'Get a trip stats',
+    description: 'Requester(Owner), Manager, Travel team member and Travel Admin can get stats of trips made in the last X timeframe',
+    parameters: [
+      {
+        name: 'body',
+        in: 'body',
+        description: 'Date',
+        required: true,
+        schema: {
+          $ref: '#/definitions/getTripStats'
+        }
+      }
+    ],
+    responses: {
+      200: {
+        description: 'resource successfully fetched',
+        schema: {
+          $ref: '#/definitions/success'
+        }
+      },
+      400: {
+        description: 'Invalid request details',
+        schema: {
+          $ref: '#/definitions/badRequest'
+        }
+      },
+      401: {
+        description: 'Unauthorized',
+        schema: {
+          $ref: '#/definitions/notAuthorized'
+        }
+      },
+      403: {
+        description: 'Access forbidden',
+        schema: {
+          $ref: '#/definitions/accessForbidden'
+        }
+      },
+      500: {
+        description: 'Server error',
+        schema: {
+          $ref: '#/definitions/serverError'
+        }
+      }
+    }
+  }
+};

--- a/src/docs/swagger/swagger.js
+++ b/src/docs/swagger/swagger.js
@@ -27,10 +27,12 @@ import {
   verifyUserPath
 } from './paths/users';
 import {
-  requestTrip, approvedTripPath, getTripPath, returnTrip, multiCityTripPath, rejectTripPath
+  requestTrip, approvedTripPath, getTripPath, returnTrip, multiCityTripPath,
+  rejectTripPath, getTripStatsPath
 } from './paths/trips';
 import {
-  createTrip, returnTripSchema, createMultiCityTrip, multiCityTripRes, rejectTripRequest,
+  createTrip, returnTripSchema, createMultiCityTrip, multiCityTripRes,
+  rejectTripRequest, getTripStats
 } from './definitions/trip';
 import { permissionsPath } from './paths/permissions';
 import { rolesPath, rolePermissionsPath } from './paths/roles';
@@ -141,6 +143,7 @@ const swaggerDocument = {
     '/trips/{tripId}/comments': getTripCommentsPath,
     '/trips/{tripId}/comments/{commentId}': deleteCommentPath,
     '/trips/return': returnTrip,
+    '/trips/stats': getTripStatsPath,
     '/accommodations': createAccommodationPath,
     '/accommodations/rooms/{accommodationId}': createRoomPath,
     '/accommodations/{accommodationId}': getAccommodationPath,
@@ -211,6 +214,7 @@ const swaggerDocument = {
     likeUnlikeAccommodationRes,
     createReview,
     FlightCreate,
+    getTripStats
   }
 };
 

--- a/src/middlewares/validateTripRequest.js
+++ b/src/middlewares/validateTripRequest.js
@@ -113,3 +113,22 @@ export const validateReturnTripForm = (req, res, next) => {
   if (!errors) return next();
   return respondWithWarning(res, 400, errors);
 };
+
+/**
+ * validate trip stats date
+ * @param {Object} req
+ * @param {Object} res
+ * @param {Function} next
+ * @returns {Object} error
+ */
+export const validateTripStatDate = (req, res, next) => {
+  const date = Joi.date().format('YYYY-MM-DD').required();
+  const schema = Joi.object().keys({
+    date
+  });
+  const errors = joiValidator(req.body, schema);
+  if (!errors) {
+    return next();
+  }
+  return respondWithWarning(res, 400, errors);
+};

--- a/src/models/triprequest.js
+++ b/src/models/triprequest.js
@@ -33,7 +33,7 @@ export default (sequelize, DataTypes) => {
     }
   }, {});
   TripRequest.associate = models => {
-    TripRequest.belongsTo(models.User, { foreignKey: 'userId', onDelete: 'CASCADE' });
+    TripRequest.belongsTo(models.User, { foreignKey: 'userId', as: 'user', onDelete: 'CASCADE' });
     TripRequest.belongsTo(models.Destination, { foreignKey: 'destinationId', as: 'destination', onDelete: 'CASCADE' });
     TripRequest.hasMany(models.Comment, { foreignKey: 'tripId' });
     TripRequest.hasMany(models.SubTripRequest, {

--- a/src/routes/api/trip.routes.js
+++ b/src/routes/api/trip.routes.js
@@ -1,9 +1,11 @@
 import { Router } from 'express';
 import {
   oneWayTripRequest, approveTripRequest, getTripRequest, returnTripRequest,
-  multiCityTripRequest, getAllTripRequests, rejectTripRequest
+  multiCityTripRequest, getAllTripRequests, rejectTripRequest, getUserTripStats, getTripStats
 } from '../../controllers/tripController';
-import { validateRequestTripForm, validateTripId, validateReturnTripForm } from '../../middlewares/validateTripRequest';
+import {
+  validateRequestTripForm, validateTripId, validateReturnTripForm, validateTripStatDate
+} from '../../middlewares/validateTripRequest';
 
 import { authenticateUserToken } from '../../middlewares/authentication';
 import { checkPermission } from '../../middlewares/checkPermission';
@@ -11,12 +13,13 @@ import { verifyTrip, checkTripStatus, verifyTripDestination } from '../../middle
 import { validateMultipleRequests } from '../../middlewares/validateMultipleRequests';
 
 const trip = Router();
-trip.post('/oneway', authenticateUserToken, validateRequestTripForm, verifyTripDestination, oneWayTripRequest);
+trip.get('/', authenticateUserToken, checkPermission('VIEW_USERS_TRIP_REQUESTS'), getAllTripRequests);
 trip.post('/multicity', authenticateUserToken, validateMultipleRequests, verifyTripDestination, multiCityTripRequest);
+trip.post('/oneway', authenticateUserToken, validateRequestTripForm, verifyTripDestination, oneWayTripRequest);
 trip.post('/return', authenticateUserToken, validateReturnTripForm, verifyTripDestination, returnTripRequest);
+trip.post('/stats', authenticateUserToken, checkPermission('VIEW_TRIP_STATS'), validateTripStatDate, getUserTripStats, getTripStats);
+trip.get('/:tripId', authenticateUserToken, validateTripId, verifyTrip, checkPermission('VIEW_USERS_TRIP_REQUESTS'), getTripRequest);
 
 trip.patch('/:tripId/approve', authenticateUserToken, validateTripId, verifyTrip, checkTripStatus, checkPermission('APPROVE_TRIP_REQUEST'), approveTripRequest);
-trip.get('/:tripId', authenticateUserToken, validateTripId, verifyTrip, checkPermission('VIEW_USERS_TRIP_REQUESTS'), getTripRequest);
-trip.get('/', authenticateUserToken, checkPermission('VIEW_USERS_TRIP_REQUESTS'), getAllTripRequests);
 trip.patch('/:tripId/reject', authenticateUserToken, validateTripId, verifyTrip, checkPermission('APPROVE_TRIP_REQUEST'), rejectTripRequest);
 export default trip;

--- a/src/services/tripServices.js
+++ b/src/services/tripServices.js
@@ -1,7 +1,9 @@
 import Model from '../models';
 import { findSingleUser } from './userServices';
 
-const { TripRequest, Destination, SubTripRequest } = Model;
+const {
+  TripRequest, Destination, SubTripRequest, User
+} = Model;
 
 export const postTrip = async (payload) => {
   try {
@@ -124,3 +126,26 @@ export const findUserTrip = async (id, userId) => TripRequest.findOne({
   where: { id, userId }
 });
 export const rejectRequest = async (tripId, status) => updateTripStatus(tripId, status);
+
+export const fetchUserTripStats = async (date, userId) => TripRequest.findAndCountAll({
+  where: {
+    userId,
+    departureDate: {
+      [Model.Sequelize.Op.between]: [new Date(date), new Date()]
+    }
+  },
+  include: [
+    { model: User, as: 'user', attributes: ['id', 'username', 'firstName', 'lastName'] }
+  ]
+});
+
+export const fetchTripStats = async (date) => TripRequest.findAndCountAll({
+  where: {
+    departureDate: {
+      [Model.Sequelize.Op.between]: [new Date(date), new Date()]
+    }
+  },
+  include: [
+    { model: User, as: 'user', attributes: ['id', 'username', 'firstName', 'lastName'] }
+  ]
+});

--- a/src/test/tripStats.test.js
+++ b/src/test/tripStats.test.js
@@ -1,0 +1,130 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../index';
+
+chai.should();
+chai.use(chaiHttp);
+
+const statsUrl = '/api/v1/trips/stats';
+const loginUrl = '/api/v1/auth/signin';
+
+const admin = {
+  email: 'admin@nomad.com',
+  password: '123456',
+};
+
+const supplier = {
+  email: 'marcus@nomad.com',
+  password: '123456',
+};
+
+const date = {
+  date: '2019-09-01'
+};
+
+let supplierToken;
+let adminToken;
+
+describe('Trip stats tests', () => {
+  before(async () => {
+    await chai.request(app)
+      .post(loginUrl)
+      .send(supplier)
+      .then((res) => {
+        supplierToken = res.body.payload.token;
+        expect(res.status).to.equal(200);
+      });
+    await chai.request(app)
+      .post(loginUrl)
+      .send(admin)
+      .then((res) => {
+        adminToken = res.body.payload.token;
+        expect(res.status).to.equal(200);
+      });
+  });
+
+  describe('Unauthenticated user cannot get trip stats', () => {
+    it('should respond with unauthenticated error', (done) => {
+      chai.request(app)
+        .post(statsUrl)
+        .send(date)
+        .end((err, res) => {
+          expect(res.status).to.equal(401);
+          expect(res.body).to.have.property('success', false);
+          done();
+        });
+    });
+  });
+
+  describe('Unauthorized user cannot get trip stats', () => {
+    it('should respond with forbidden error', (done) => {
+      chai.request(app)
+        .post(statsUrl)
+        .set('Authorization', supplierToken)
+        .send(date)
+        .end((err, res) => {
+          expect(res.status).to.equal(403);
+          expect(res.body).to.have.property('success', false);
+          done();
+        });
+    });
+  });
+
+  describe('Can get trip stats', () => {
+    it('should respond with status 200 and date data', (done) => {
+      chai.request(app)
+        .post(statsUrl)
+        .set('Authorization', adminToken)
+        .send(date)
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.property('success', true);
+          done();
+        });
+    });
+  });
+
+  describe('Cannot get trip stats invalid data', () => {
+    describe('Cannot create record with invalid date', () => {
+      it('should respond with error for empty field', (done) => {
+        chai.request(app)
+          .post(statsUrl)
+          .set('Authorization', adminToken)
+          .send({
+            date: '',
+          })
+          .end((err, res) => {
+            expect(res.status).to.equal(400);
+            expect(res.body).to.have.property('success', false);
+            done();
+          });
+      });
+      it('should respond with error for invalid date', (done) => {
+        chai.request(app)
+          .post(statsUrl)
+          .set('Authorization', adminToken)
+          .send({
+            date: 'hello',
+          })
+          .end((err, res) => {
+            expect(res.status).to.equal(400);
+            expect(res.body).to.have.property('success', false);
+            done();
+          });
+      });
+      it('should respond with error for white spaces', (done) => {
+        chai.request(app)
+          .post(statsUrl)
+          .set('Authorization', adminToken)
+          .send({
+            date: '         ',
+          })
+          .end((err, res) => {
+            expect(res.status).to.equal(400);
+            expect(res.body).to.have.property('success', false);
+            done();
+          });
+      });
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?

- A user can get detailed statistics of the number of trips he/she has made in the recent past

#### Description of Task to be completed?

- Create trip stats route
- Validate date
- Fetch trips between timeframe to user
- Write swagger documentation
- Write tests for feature

#### Any background context you want to provide?
-  Users were not able to get statistics of trips made within a timeframe. This PR enables this feature

#### How should this be manually tested?

- Fetch branch `ft-trip-stats-167727340 `
- `npm install`
- `npm run migration`
- `npm run db:seed`
- `npm run start-dev`
- Send a post request to `/api/v1/trips/stats` with date field

#### What are the relevant PT stories?
(#167727340 )[https://www.pivotaltracker.com/story/show/167727338]